### PR TITLE
Add plist->map

### DIFF
--- a/cl-messagepack.lisp
+++ b/cl-messagepack.lisp
@@ -40,6 +40,10 @@
   "Alist predicate"
   (and (consp l) (consp (car l)) (atom (caar l))))
 
+(defun plistp (l)
+  "Plist predicate."
+  (and (consp l) (keywordp (car l)) (consp (cdr l))))
+
 (defmacro signed-unsigned-convertors (size)
   `(progn
      (defun ,(mksymb 'sb size '-> 'ub size) (sb)
@@ -145,7 +149,7 @@
         ((vectorp data)
          (encode-array data stream))
         ((consp data)
-         (if (alistp data)
+         (if (or (alistp data) (plistp data))
              (encode-hash data stream)
              (encode-array data stream)))
         ((hash-table-p data)
@@ -223,6 +227,11 @@
          (dolist (pair data)
            (encode-stream (car pair) stream)
            (encode-stream (cdr pair) stream)))
+	((plistp data)
+	 (loop
+	    for lst on data by #'cddr
+	    do (progn (encode-stream (car  lst) stream)
+		      (encode-stream (cadr lst) stream))))
         ((vectorp data)
          (dotimes (i (length data))
            (encode-stream (aref data i) stream)))

--- a/tests.lisp
+++ b/tests.lisp
@@ -96,13 +96,37 @@ encode properly."
                (loop
                   for i from 1 to size
                   do (setf (gethash i result) (- i)))
-               result)))
+               result))
+	   (make-alist (size)
+	     (let ((result ()))
+	       (loop
+		  for i from 1 to size
+		  do (push (cons i (- i)) result))
+	       result))
+	   (make-plist (size)
+	     (loop
+		for i from 1 to size
+		append (list (intern (write-to-string i) :keyword) (- i)))))
     (is (equalp #(#x8A)
                 (subseq (mpk:encode (make-map 10)) 0 1)))
+    (is (equalp #(#x8A)
+                (subseq (mpk:encode (make-alist 10)) 0 1)))
+    (is (equalp #(#x8A)
+                (subseq (mpk:encode (make-plist 10)) 0 1)))
     (is (equalp #(#xDE #x00 #x10)
                 (subseq  (mpk:encode (make-map 16)) 0 3)))
+    (is (equalp #(#xDE #x00 #x10)
+                (subseq  (mpk:encode (make-alist 16)) 0 3)))
+    (is (equalp #(#xDE #x00 #x10)
+                (subseq  (mpk:encode (make-plist 16)) 0 3)))
     (is (equalp #(#xDF #x00 #x01 #x00 #x00)
                 (subseq (mpk:encode (make-map 65536))
+                        0 5)))
+    (is (equalp #(#xDF #x00 #x01 #x00 #x00)
+                (subseq (mpk:encode (make-alist 65536))
+                        0 5)))
+    (is (equalp #(#xDF #x00 #x01 #x00 #x00)
+                (subseq (mpk:encode (make-plist 65536))
                         0 5)))))
 
 (test extension-cons


### PR DESCRIPTION
Added the ability plist->map and tests for alist->map and plist->map.
Though commit message indicates keyword->string is also added, I gave it up because I noticed symbol->string did. (But I like `:foo` to be `"FOO"` rather than `":FOO"`)
