### PR TITLE
Support bin 16 and bin 32 types and decode bin as str

### DIFF
--- a/cl-messagepack.lisp
+++ b/cl-messagepack.lisp
@@ -107,6 +107,7 @@
 (defvar *symbol->int* nil)
 (defvar *decoder-prefers-lists* nil)
 (defvar *decoder-prefers-alists* nil)
+(defvar *decode-bin-as-string* nil)
 
 (defvar *extended-types* nil)
 (defvar *lookup-table* nil)
@@ -400,11 +401,11 @@
           ((= #xdf byte)
            (decode-map (load-big-endian stream 4) stream))
           ((= #xc4 byte)
-           (decode-array (read-byte stream) stream))
+           (funcall (if *decode-bin-as-string* #'decode-string #'decode-array) (read-byte stream) stream))
           ((= #xc5 byte)
-           (decode-array (load-big-endian stream 2) stream))
+           (funcall (if *decode-bin-as-string* #'decode-string #'decode-array) (load-big-endian stream 2) stream))
           ((= #xc6 byte)
-           (decode-array (load-big-endian stream 4) stream))
+           (funcall (if *decode-bin-as-string* #'decode-string #'decode-array) (load-big-endian stream 4) stream))
           (t (error
               (format nil
                       "Cannot decode ~a (maybe you should bind *extended-types*?)" byte))))))

--- a/cl-messagepack.lisp
+++ b/cl-messagepack.lisp
@@ -401,6 +401,10 @@
            (decode-map (load-big-endian stream 4) stream))
           ((= #xc4 byte)
            (decode-array (read-byte stream) stream))
+          ((= #xc5 byte)
+           (decode-array (load-big-endian stream 2) stream))
+          ((= #xc6 byte)
+           (decode-array (load-big-endian stream 4) stream))
           (t (error
               (format nil
                       "Cannot decode ~a (maybe you should bind *extended-types*?)" byte))))))

--- a/package.lisp
+++ b/package.lisp
@@ -43,7 +43,8 @@
            define-extension-types
            symbol-to-extension-type
            *decoder-prefers-lists*
-           *decoder-prefers-alists*))
+           *decoder-prefers-alists*
+           *decode-bin-as-string*))
 
 (defpackage #:messagepack-tests
   (:use #:cl #:fiveam)


### PR DESCRIPTION
I would submit this as 2 separate pull requests, but I cannot figure out how to do that at all. In any case, first commit adds support for decoding 0xc5 (bin 16) and 0xc6 (bin 32) as per [msgpack spec](https://github.com/msgpack/msgpack/blob/master/spec.md#bin-format-family).

Second commit is IMHO a bit controversial. It adds *decode-bin-as-string* which, when set to T, tells the decoder to read binary arrays as strings. This is useful because some programs (namely [neovim](https://github.com/neovim/neovim)), [due to supporting various encodings](https://github.com/neovim/neovim/pull/1130) on their side of things, send strings using this type.

On one hand by default this commit doesn't *really* affect users that don't want/expect this behavior, but on the other hand it can easily be argued that interpreting bin as str is not really the work of cl-messagepack. I'll leave the decision up to you.