### PR TITLE
Fix caching for ext types with :byte-array data

### DIFF
--- a/cl-messagepack.asd
+++ b/cl-messagepack.asd
@@ -24,7 +24,7 @@
 
 (asdf:defsystem #:cl-messagepack
   :serial t
-  :depends-on (:flexi-streams :babel :cl-json :fiveam :closer-mop :access)
+  :depends-on (:flexi-streams :babel :cl-json :fiveam :closer-mop)
   :description "A Common-Lisp implementation of Message Pack serialization."
   :author "Miron Brezuleanu"
   :license "Simplified BSD License"

--- a/cl-messagepack.lisp
+++ b/cl-messagepack.lisp
@@ -525,14 +525,8 @@
       ((maybe-cache (obj id)
          (if *lookup-table*
            (or
-             (access:accesses *lookup-table*
-                              `(,num :type array)
-                              `(,id :type array))
-             (setf
-               (access:accesses *lookup-table*
-                                    `(,num :type array)
-                                    `(,id :type array))
-               obj))
+             (lookup-table-find num id)
+             (lookup-table-insert num id obj))
            obj)))
       (make-instance 'extension-type-description
                      :type-number  num
@@ -637,7 +631,10 @@
 
 (defun make-lookup-table ()
   "Returns something that can be used for *LOOKUP-TABLE*."
-  (make-array 10
-              :initial-element NIL
-              :adjustable T
-              :fill-pointer T))
+  (make-hash-table :test #'equalp))
+
+(defun lookup-table-insert (type id obj)
+  (setf (gethash (cons type id) *lookup-table*) obj))
+
+(defun lookup-table-find (type id)
+  (gethash (cons type id) *lookup-table*))


### PR DESCRIPTION
With this patch ext types with non-numeric data should get cached properly.