### PR TITLE
Add option to disable encoding alists as maps

### DIFF
--- a/cl-messagepack.lisp
+++ b/cl-messagepack.lisp
@@ -105,6 +105,7 @@
 (defvar *symbol->int* nil)
 (defvar *int->symbol* nil)
 (defvar *symbol->int* nil)
+(defvar *encode-alist-as-map* T)
 (defvar *decoder-prefers-lists* nil)
 (defvar *decoder-prefers-alists* nil)
 (defvar *decode-bin-as-string* nil)
@@ -152,7 +153,7 @@
         ((vectorp data)
          (encode-array data stream))
         ((consp data)
-         (if (or (alistp data) (plistp data))
+         (if (or (and *encode-alist-as-map* (alistp data)) (plistp data))
              (encode-hash data stream)
              (encode-array data stream)))
         ((hash-table-p data)
@@ -219,15 +220,15 @@
                     (encode-stream key stream)
                     (encode-stream value stream))
                   data))
-        ((alistp data)
+        ((and *encode-alist-as-map* (alistp data))
          (dolist (pair data)
            (encode-stream (car pair) stream)
            (encode-stream (cdr pair) stream)))
-	((plistp data)
-	 (loop
-	    for lst on data by #'cddr
-	    do (progn (encode-stream (car  lst) stream)
-		      (encode-stream (cadr lst) stream))))
+        ((plistp data)
+         (loop
+           for lst on data by #'cddr
+           do (progn (encode-stream (car  lst) stream)
+                     (encode-stream (cadr lst) stream))))
         ((vectorp data)
          (dotimes (i (length data))
            (encode-stream (aref data i) stream)))

--- a/package.lisp
+++ b/package.lisp
@@ -43,6 +43,7 @@
            make-lookup-table
            define-extension-types
            symbol-to-extension-type
+           *encode-alist-as-map*
            *decoder-prefers-lists*
            *decoder-prefers-alists*
            *decode-bin-as-string*))

--- a/tests.lisp
+++ b/tests.lisp
@@ -90,6 +90,15 @@ encode properly."
                       0
                       15))))
 
+(test alists
+  "Test alists can be encoded into either map or lists of lists depending on
+*encode-alist-as-hash*."
+  (let ((alist '((1 11 12) ("b" "bc"))))
+    (is (equalp #(#x82 #x01 #x92 #x0B #x0C #xA1 #x62 #x91 #xA2 #x62 #x63)
+                (mpk:encode alist)))
+    (is (equalp #(#x92 #x93 #x01 #x0B #x0C #x92 #xA1 #x62 #xA2 #x62 #x63)
+                (let ((mpk:*encode-alist-as-map*)) (mpk:encode alist))))))
+
 (test maps
   "Test maps of various sizes, make sure that lengths are encoded
   properly."


### PR DESCRIPTION
This patch adds `*encode-alist-as-map*` variable which by default (set to `T`) doesn't change the behavior, but when set to `NIL` encodes alists as just lists-of-lists (or rather, arrays-of-arrays) instead of maps.