### PR TITLE
setting *use-null* to t decodes xc0 to 'null

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ for some Lisp data types (see below), simple tests.
 
 ### (C0) 'NIL'
 
-This translates to `NIL` in Lisp directly, but see `C2` (`False`) below, too.
+If `*use-null*` is kept `NIL`, `C0` translates to `NIL` in Lisp; else it translates to `'NULL` (symbol).  Also see `C2` (`False`) below, too.
 
 ### (C2) 'False'
 

--- a/cl-messagepack.lisp
+++ b/cl-messagepack.lisp
@@ -102,6 +102,7 @@
             collect `(write-byte (ldb (byte 8 ,(* 8 i)) ,g-number) ,g-stream)))))
 
 (defvar *use-false* nil)
+(defvar *use-null* nil)
 (defvar *symbol->int* nil)
 (defvar *int->symbol* nil)
 (defvar *symbol->int* nil)
@@ -374,7 +375,7 @@
              (typed-data (read-byte stream)
                          (decode-byte-array len stream))))
           ((= #xc0 byte)
-           nil)
+           (if *use-null* 'null nil))
           ((= #xc3 byte)
            t)
           ((= #xc2 byte)

--- a/package.lisp
+++ b/package.lisp
@@ -33,6 +33,7 @@
   (:export encode encode-stream
            decode decode-stream
            write-hex
+           *use-null*
            *symbol->int*
            *int->symbol*
            get-symbol-int-table

--- a/tests.lisp
+++ b/tests.lisp
@@ -164,7 +164,9 @@ encode properly."
 (test decoding-bools
   "Test that (equalp (decode (encode data)) data) for bools."
   (is (eql t (mpk:decode (mpk:encode t))))
-  (is (eql nil (mpk:decode (mpk:encode nil)))))
+  (is (eql nil (mpk:decode (mpk:encode nil))))
+  (is (eql 'null (let ((mpk:*use-null* t))
+                      (mpk:decode (mpk:encode nil))))))
 
 (test decoding-floats
   "Test that (equalp (decode (encode data)) data) for floats."


### PR DESCRIPTION
As it is, `cl-messagepack` does not distinguish  between decoding `xc0` and decoding `xc2`: they both decode to `nil` in Lisp.  However there may be cases when this distinction is important (e.g. [cl-transit](https://github.com/jsulmont/cl-transit)).
This PR introduces a top level variable `*use-null*` which when not `nil` decodes `xc0` to `'null`.
